### PR TITLE
Add field options overlay for selectable Jira fields

### DIFF
--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -37,7 +37,6 @@ jobs:
         run: npm run test
 
   deploy:
-    if: github.event_name != 'pull_request'
     needs: ci
     runs-on: ubuntu-latest
     permissions:
@@ -71,7 +70,9 @@ jobs:
 
           # Determine environment based on branch
           BRANCH_NAME="${{ github.ref_name }}"
-          if [ "$BRANCH_NAME" = "main" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ENVIRONMENT="development"
+          elif [ "$BRANCH_NAME" = "main" ]; then
             ENVIRONMENT="production"
           elif [ "$BRANCH_NAME" = "develop" ]; then
             ENVIRONMENT="staging"

--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -2,10 +2,9 @@ name: Deploy Atlassian Forge App
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'main', 'develop' ]
   pull_request:
-    branches: [ '**' ]
-  workflow_dispatch: # allows manual runs from the GitHub UI
+    branches: [ 'main', 'develop' ]
 
 jobs:
   ci:
@@ -82,4 +81,15 @@ jobs:
 
           echo "Deploying to Forge environment: $ENVIRONMENT"
 
-          forge deploy --non-interactive -e "$ENVIRONMENT"
+          ATTEMPT=1
+          MAX_ATTEMPTS=4
+          until forge deploy --non-interactive -e "$ENVIRONMENT"; do
+            if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "Forge deploy failed after $MAX_ATTEMPTS attempts."
+              exit 1
+            fi
+            SLEEP_SECONDS=$((ATTEMPT * 20))
+            echo "Forge environment appears busy. Retrying in ${SLEEP_SECONDS}s..."
+            sleep "$SLEEP_SECONDS"
+            ATTEMPT=$((ATTEMPT + 1))
+          done

--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -2,12 +2,49 @@ name: Deploy Atlassian Forge App
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
   workflow_dispatch: # allows manual runs from the GitHub UI
 
 jobs:
-  deploy:
+  ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: atlassian-jira-fields-viewer
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: atlassian-jira-fields-viewer/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: atlassian-jira-fields-viewer
 
     steps:
       - name: Checkout repository
@@ -24,19 +61,7 @@ jobs:
         run: npm install -g @forge/cli
 
       - name: Install dependencies
-        run: |
-          cd atlassian-jira-fields-viewer
-          npm ci
-
-      - name: Run linter
-        run: |
-          cd atlassian-jira-fields-viewer
-          npm run lint
-
-      - name: Run tests
-        run: |
-          cd atlassian-jira-fields-viewer
-          npm run test
+        run: npm ci
 
       - name: Deploy Forge App
         run: |
@@ -55,5 +80,4 @@ jobs:
 
           echo "Deploying to Forge environment: $ENVIRONMENT"
 
-          cd atlassian-jira-fields-viewer
           forge deploy --non-interactive -e "$ENVIRONMENT"

--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -70,9 +70,10 @@ jobs:
           forge settings set usage-analytics false
 
           # Determine environment based on branch
-          if [ "${GITHUB_REF##*/}" = "main" ]; then
+          BRANCH_NAME="${{ github.ref_name }}"
+          if [ "$BRANCH_NAME" = "main" ]; then
             ENVIRONMENT="production"
-          elif [ "${GITHUB_REF##*/}" = "develop" ]; then
+          elif [ "$BRANCH_NAME" = "develop" ]; then
             ENVIRONMENT="staging"
           else
             ENVIRONMENT="development"

--- a/atlassian-jira-fields-viewer/manifest.yml
+++ b/atlassian-jira-fields-viewer/manifest.yml
@@ -26,3 +26,4 @@ permissions:
     - read:jira-work
     - read:field:jira
     - read:field.option:jira
+    - manage:jira-configuration

--- a/atlassian-jira-fields-viewer/manifest.yml
+++ b/atlassian-jira-fields-viewer/manifest.yml
@@ -25,3 +25,4 @@ permissions:
   #https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/
     - read:jira-work
     - read:field:jira
+    - read:field.option:jira

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -110,7 +110,7 @@ export const App = () => {
     return () => {
       isCancelled = true;
     };
-  }, [fields, fieldOptionState]);
+  }, [fields]);
 
   const formatOptionValues = (options, limit) => {
     if (!options.length) {

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -9,7 +9,7 @@ import ForgeReconciler, {
   TabPanel,
   Box,
   Tooltip,
-  Pressable,
+  Button,
 } from '@forge/react';
 import { invoke } from '@forge/bridge';
 
@@ -100,6 +100,15 @@ export const App = () => {
     const fieldState = fieldOptionState[fieldId];
     const optionCount = fieldState?.status === 'loaded' ? fieldState.options.length : null;
     const label = optionCount && optionCount > 0 ? `${fieldType} (${optionCount})` : fieldType;
+    const isLoading = fieldState?.status === 'loading';
+    const isError = fieldState?.status === 'error';
+    const buttonText = isLoading
+      ? `${label} (loading...)`
+      : isError
+        ? `${label} (retry)`
+        : optionCount === null
+          ? `${label} (show options)`
+          : label;
 
     const loadOptions = async () => {
       if (!fieldId) {
@@ -131,9 +140,12 @@ export const App = () => {
 
     return (
       <Tooltip text={getOptionsTooltipText(fieldId)}>
-        <Pressable onPress={loadOptions} ariaLabel={`Load options for ${field.name || field.key || field.id}`}>
-          {label}
-        </Pressable>
+        <Button
+          text={buttonText}
+          appearance="subtle"
+          onClick={loadOptions}
+          disabled={isLoading}
+        />
       </Tooltip>
     );
   };

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -30,6 +30,7 @@ export const App = () => {
       { key: 'name', content: 'Field Name' },
       { key: 'key', content: 'Field ID' },
       { key: 'type', content: 'Field Type' },
+      { key: 'options', content: 'Options' },
       { key: 'projectName', content: 'Project Name' },
     ],
   };
@@ -149,6 +150,36 @@ export const App = () => {
     );
   };
 
+  const getFieldOptionsContent = (field) => {
+    if (!isOptionBasedField(field)) {
+      return '-';
+    }
+
+    const fieldId = field?.id;
+    const fieldState = fieldOptionState[fieldId];
+
+    if (!fieldState || fieldState.status === 'loading') {
+      return 'Loading options...';
+    }
+
+    if (fieldState.status === 'error') {
+      return 'Options unavailable';
+    }
+
+    if (fieldState.status === 'loaded') {
+      if (!fieldState.options.length) {
+        return 'No options';
+      }
+
+      const visible = fieldState.options.slice(0, 3);
+      const hiddenCount = fieldState.options.length - visible.length;
+      const preview = visible.join(', ');
+      return hiddenCount > 0 ? `${preview} (+${hiddenCount} more)` : preview;
+    }
+
+    return 'Loading options...';
+  };
+
   const mapFieldsToRows = (fields) => {
     return fields.map((field, index) => ({
       key: field.id || `row-${index}`,
@@ -157,6 +188,7 @@ export const App = () => {
         { key: 'name', content: field.name },
         { key: 'key', content: field.key },
         { key: 'type', content: getFieldTypeContent(field) },
+        { key: 'options', content: getFieldOptionsContent(field) },
         { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
       ],
     }));

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -79,7 +79,7 @@ export const App = () => {
         };
       });
 
-      invoke('getFieldOptions', { fieldId })
+      invoke('getFieldOptions', { fieldId, projectId: field?.scope?.project?.id })
         .then((options) => {
           setFieldOptionState((prev) => ({
             ...prev,

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -9,7 +9,6 @@ import ForgeReconciler, {
   TabPanel,
   Box,
   Tooltip,
-  Button,
 } from '@forge/react';
 import { invoke } from '@forge/bridge';
 
@@ -60,11 +59,46 @@ export const App = () => {
     );
   };
 
+  useEffect(() => {
+    const optionFields = fields.filter(isOptionBasedField);
+
+    optionFields.forEach((field) => {
+      const fieldId = field?.id;
+      if (!fieldId) {
+        return;
+      }
+
+      setFieldOptionState((prev) => {
+        if (prev[fieldId]) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [fieldId]: { status: 'loading', options: [] },
+        };
+      });
+
+      invoke('getFieldOptions', { fieldId })
+        .then((options) => {
+          setFieldOptionState((prev) => ({
+            ...prev,
+            [fieldId]: { status: 'loaded', options: Array.isArray(options) ? options : [] },
+          }));
+        })
+        .catch(() => {
+          setFieldOptionState((prev) => ({
+            ...prev,
+            [fieldId]: { status: 'error', options: [] },
+          }));
+        });
+    });
+  }, [fields]);
+
   const getOptionsTooltipText = (fieldId) => {
     const fieldState = fieldOptionState[fieldId];
 
     if (!fieldState) {
-      return 'Hover for details, click to load field options';
+      return 'Loading options...';
     }
 
     if (fieldState.status === 'loading') {
@@ -87,7 +121,7 @@ export const App = () => {
       return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
     }
 
-    return 'Click to load field options';
+    return 'Loading options...';
   };
 
   const getFieldTypeContent = (field) => {
@@ -99,53 +133,18 @@ export const App = () => {
     const fieldId = field?.id;
     const fieldState = fieldOptionState[fieldId];
     const optionCount = fieldState?.status === 'loaded' ? fieldState.options.length : null;
-    const label = optionCount && optionCount > 0 ? `${fieldType} (${optionCount})` : fieldType;
-    const isLoading = fieldState?.status === 'loading';
+    const isLoading = !fieldState || fieldState?.status === 'loading';
     const isError = fieldState?.status === 'error';
-    const buttonText = isLoading
+    const label = optionCount && optionCount > 0 ? `${fieldType} (${optionCount})` : fieldType;
+    const text = isLoading
       ? `${label} (loading...)`
       : isError
-        ? `${label} (retry)`
-        : optionCount === null
-          ? `${label} (show options)`
-          : label;
-
-    const loadOptions = async () => {
-      if (!fieldId) {
-        return;
-      }
-
-      if (fieldState?.status === 'loaded' || fieldState?.status === 'loading') {
-        return;
-      }
-
-      setFieldOptionState((prev) => ({
-        ...prev,
-        [fieldId]: { status: 'loading', options: [] },
-      }));
-
-      try {
-        const options = await invoke('getFieldOptions', { fieldId });
-        setFieldOptionState((prev) => ({
-          ...prev,
-          [fieldId]: { status: 'loaded', options: Array.isArray(options) ? options : [] },
-        }));
-      } catch (error) {
-        setFieldOptionState((prev) => ({
-          ...prev,
-          [fieldId]: { status: 'error', options: [] },
-        }));
-      }
-    };
+        ? `${label} (options unavailable)`
+        : label;
 
     return (
       <Tooltip text={getOptionsTooltipText(fieldId)}>
-        <Button
-          text={buttonText}
-          appearance="subtle"
-          onClick={loadOptions}
-          disabled={isLoading}
-        />
+        {text}
       </Tooltip>
     );
   };

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -1,11 +1,23 @@
 import React, { useEffect, useState } from 'react';
-import ForgeReconciler, { Label, DynamicTable, Textfield, Tabs, TabList, Tab, TabPanel, Box} from '@forge/react';
+import ForgeReconciler, {
+  Label,
+  DynamicTable,
+  Textfield,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
+  Box,
+  Tooltip,
+  Pressable,
+} from '@forge/react';
 import { invoke } from '@forge/bridge';
 
 export const App = () => {
   const [fields, setFields] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('');
+  const [fieldOptionState, setFieldOptionState] = useState({});
 
   useEffect(() => {
     invoke('getAllFields')
@@ -33,6 +45,99 @@ export const App = () => {
     });
   };
 
+  const isOptionBasedField = (field) => {
+    const type = field?.schema?.type?.toLowerCase?.() || '';
+    const items = field?.schema?.items?.toLowerCase?.() || '';
+    const custom = field?.schema?.custom?.toLowerCase?.() || '';
+
+    return (
+      type === 'option' ||
+      items === 'option' ||
+      custom.includes('select') ||
+      custom.includes('checkbox') ||
+      custom.includes('radio') ||
+      custom.includes('cascading')
+    );
+  };
+
+  const getOptionsTooltipText = (fieldId) => {
+    const fieldState = fieldOptionState[fieldId];
+
+    if (!fieldState) {
+      return 'Hover for details, click to load field options';
+    }
+
+    if (fieldState.status === 'loading') {
+      return 'Loading options...';
+    }
+
+    if (fieldState.status === 'error') {
+      return 'Unable to load options';
+    }
+
+    if (fieldState.status === 'loaded') {
+      if (!fieldState.options.length) {
+        return 'No options found for this field';
+      }
+
+      const visibleOptions = fieldState.options.slice(0, 20);
+      const hiddenCount = fieldState.options.length - visibleOptions.length;
+      const optionText = visibleOptions.join(', ');
+
+      return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
+    }
+
+    return 'Click to load field options';
+  };
+
+  const getFieldTypeContent = (field) => {
+    const fieldType = field.schema?.type || 'N/A';
+    if (!isOptionBasedField(field)) {
+      return fieldType;
+    }
+
+    const fieldId = field?.id;
+    const fieldState = fieldOptionState[fieldId];
+    const optionCount = fieldState?.status === 'loaded' ? fieldState.options.length : null;
+    const label = optionCount && optionCount > 0 ? `${fieldType} (${optionCount})` : fieldType;
+
+    const loadOptions = async () => {
+      if (!fieldId) {
+        return;
+      }
+
+      if (fieldState?.status === 'loaded' || fieldState?.status === 'loading') {
+        return;
+      }
+
+      setFieldOptionState((prev) => ({
+        ...prev,
+        [fieldId]: { status: 'loading', options: [] },
+      }));
+
+      try {
+        const options = await invoke('getFieldOptions', { fieldId });
+        setFieldOptionState((prev) => ({
+          ...prev,
+          [fieldId]: { status: 'loaded', options: Array.isArray(options) ? options : [] },
+        }));
+      } catch (error) {
+        setFieldOptionState((prev) => ({
+          ...prev,
+          [fieldId]: { status: 'error', options: [] },
+        }));
+      }
+    };
+
+    return (
+      <Tooltip text={getOptionsTooltipText(fieldId)}>
+        <Pressable onPress={loadOptions} ariaLabel={`Load options for ${field.name || field.key || field.id}`}>
+          {label}
+        </Pressable>
+      </Tooltip>
+    );
+  };
+
   const mapFieldsToRows = (fields) => {
     return fields.map((field, index) => ({
       key: field.id || `row-${index}`,
@@ -40,7 +145,7 @@ export const App = () => {
         { key: 'number', content: index + 1 },
         { key: 'name', content: field.name },
         { key: 'key', content: field.key },
-        { key: 'type', content: field.schema?.type || 'N/A' },
+        { key: 'type', content: getFieldTypeContent(field) },
         { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
       ],
     }));

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -12,6 +12,24 @@ import ForgeReconciler, {
 } from '@forge/react';
 import { invoke } from '@forge/bridge';
 
+const fetchFieldOptionEntry = async (field) => {
+  const fieldId = field.id;
+  try {
+    const options = await invoke('getFieldOptions', {
+      fieldId,
+      projectId: field?.scope?.project?.id,
+    });
+    return [fieldId, { status: 'loaded', options: Array.isArray(options) ? options : [] }];
+  } catch {
+    return [fieldId, { status: 'error', options: [] }];
+  }
+};
+
+const fetchMissingFieldOptions = async (missingFields) => {
+  const results = await Promise.all(missingFields.map(fetchFieldOptionEntry));
+  return Object.fromEntries(results);
+};
+
 export const App = () => {
   const [fields, setFields] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -61,137 +79,108 @@ export const App = () => {
   };
 
   useEffect(() => {
-    const optionFields = fields.filter(isOptionBasedField);
+    const optionFields = fields.filter(isOptionBasedField).filter((field) => field?.id);
+    const missingFields = optionFields.filter((field) => !fieldOptionState[field.id]);
 
-    optionFields.forEach((field) => {
-      const fieldId = field?.id;
-      if (!fieldId) {
+    if (!missingFields.length) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    const loadingStateByFieldId = Object.fromEntries(
+      missingFields.map((field) => [field.id, { status: 'loading', options: [] }])
+    );
+    setFieldOptionState((prev) => ({
+      ...prev,
+      ...loadingStateByFieldId,
+    }));
+
+    fetchMissingFieldOptions(missingFields).then((resolvedFieldOptionState) => {
+      if (isCancelled) {
         return;
       }
 
-      setFieldOptionState((prev) => {
-        if (prev[fieldId]) {
-          return prev;
-        }
-        return {
-          ...prev,
-          [fieldId]: { status: 'loading', options: [] },
-        };
-      });
-
-      invoke('getFieldOptions', { fieldId, projectId: field?.scope?.project?.id })
-        .then((options) => {
-          setFieldOptionState((prev) => ({
-            ...prev,
-            [fieldId]: { status: 'loaded', options: Array.isArray(options) ? options : [] },
-          }));
-        })
-        .catch(() => {
-          setFieldOptionState((prev) => ({
-            ...prev,
-            [fieldId]: { status: 'error', options: [] },
-          }));
-        });
+      setFieldOptionState((prev) => ({
+        ...prev,
+        ...resolvedFieldOptionState,
+      }));
     });
-  }, [fields]);
 
-  const getOptionsTooltipText = (fieldId) => {
-    const fieldState = fieldOptionState[fieldId];
+    return () => {
+      isCancelled = true;
+    };
+  }, [fields, fieldOptionState]);
 
-    if (!fieldState) {
-      return 'Loading options...';
+  const formatOptionValues = (options, limit) => {
+    if (!options.length) {
+      return null;
     }
 
-    if (fieldState.status === 'loading') {
-      return 'Loading options...';
-    }
-
-    if (fieldState.status === 'error') {
-      return 'Unable to load options';
-    }
-
-    if (fieldState.status === 'loaded') {
-      if (!fieldState.options.length) {
-        return 'No options found for this field';
-      }
-
-      const visibleOptions = fieldState.options.slice(0, 20);
-      const hiddenCount = fieldState.options.length - visibleOptions.length;
-      const optionText = visibleOptions.join(', ');
-
-      return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
-    }
-
-    return 'Loading options...';
+    const visibleOptions = options.slice(0, limit);
+    const hiddenCount = options.length - visibleOptions.length;
+    const optionText = visibleOptions.join(', ');
+    return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
   };
 
-  const getFieldTypeContent = (field) => {
+  const getOptionDisplayModel = (field) => {
+    if (!isOptionBasedField(field)) {
+      return null;
+    }
+
     const fieldType = field.schema?.type || 'N/A';
-    if (!isOptionBasedField(field)) {
-      return fieldType;
+    const fieldState = fieldOptionState[field?.id];
+
+    if (fieldState && fieldState.status === 'error') {
+      return {
+        typeText: `${fieldType} (options unavailable)`,
+        optionsText: 'Options unavailable',
+        tooltipText: 'Unable to load options',
+      };
     }
 
-    const fieldId = field?.id;
-    const fieldState = fieldOptionState[fieldId];
-    const optionCount = fieldState?.status === 'loaded' ? fieldState.options.length : null;
-    const isLoading = !fieldState || fieldState?.status === 'loading';
-    const isError = fieldState?.status === 'error';
-    const label = optionCount !== null ? `${fieldType} (${optionCount})` : fieldType;
-    const text = isLoading
-      ? `${label} (loading...)`
-      : isError
-        ? `${label} (options unavailable)`
-        : label;
+    if (fieldState && fieldState.status === 'loaded') {
+      const options = fieldState.options || [];
+      const optionCount = options.length;
 
-    return (
-      <Tooltip text={getOptionsTooltipText(fieldId)}>
-        {text}
-      </Tooltip>
-    );
-  };
-
-  const getFieldOptionsContent = (field) => {
-    if (!isOptionBasedField(field)) {
-      return '-';
+      return {
+        typeText: `${fieldType} (${optionCount})`,
+        optionsText: formatOptionValues(options, 3) || 'No options',
+        tooltipText: formatOptionValues(options, 20) || 'No options found for this field',
+      };
     }
 
-    const fieldId = field?.id;
-    const fieldState = fieldOptionState[fieldId];
-
-    if (!fieldState || fieldState.status === 'loading') {
-      return 'Loading options...';
-    }
-
-    if (fieldState.status === 'error') {
-      return 'Options unavailable';
-    }
-
-    if (fieldState.status === 'loaded') {
-      if (!fieldState.options.length) {
-        return 'No options';
-      }
-
-      const visible = fieldState.options.slice(0, 3);
-      const hiddenCount = fieldState.options.length - visible.length;
-      const preview = visible.join(', ');
-      return hiddenCount > 0 ? `${preview} (+${hiddenCount} more)` : preview;
-    }
-
-    return 'Loading options...';
+    return {
+      typeText: `${fieldType} (loading...)`,
+      optionsText: 'Loading options...',
+      tooltipText: 'Loading options...',
+    };
   };
 
   const mapFieldsToRows = (fields) => {
-    return fields.map((field, index) => ({
-      key: field.id || `row-${index}`,
-      cells: [
-        { key: 'number', content: index + 1 },
-        { key: 'name', content: field.name },
-        { key: 'key', content: field.key },
-        { key: 'type', content: getFieldTypeContent(field) },
-        { key: 'options', content: getFieldOptionsContent(field) },
-        { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
-      ],
-    }));
+    return fields.map((field, index) => {
+      const optionDisplayModel = getOptionDisplayModel(field);
+      return {
+        key: field.id || `row-${index}`,
+        cells: [
+          { key: 'number', content: index + 1 },
+          { key: 'name', content: field.name },
+          { key: 'key', content: field.key },
+          {
+            key: 'type',
+            content: optionDisplayModel ? (
+              <Tooltip text={optionDisplayModel.tooltipText}>
+                {optionDisplayModel.typeText}
+              </Tooltip>
+            ) : (
+              field.schema?.type || 'N/A'
+            ),
+          },
+          { key: 'options', content: optionDisplayModel?.optionsText || '-' },
+          { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
+        ],
+      };
+    });
   };
 
   const getDuplicateFields = (fields) => {

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -135,7 +135,7 @@ export const App = () => {
     const optionCount = fieldState?.status === 'loaded' ? fieldState.options.length : null;
     const isLoading = !fieldState || fieldState?.status === 'loading';
     const isError = fieldState?.status === 'error';
-    const label = optionCount && optionCount > 0 ? `${fieldType} (${optionCount})` : fieldType;
+    const label = optionCount !== null ? `${fieldType} (${optionCount})` : fieldType;
     const text = isLoading
       ? `${label} (loading...)`
       : isError

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -131,7 +131,7 @@ export const App = () => {
     const fieldType = field.schema?.type || 'N/A';
     const fieldState = fieldOptionState[field?.id];
 
-    if (fieldState && fieldState.status === 'error') {
+    if (fieldState?.status === 'error') {
       return {
         typeText: `${fieldType} (options unavailable)`,
         optionsText: 'Options unavailable',
@@ -139,7 +139,7 @@ export const App = () => {
       };
     }
 
-    if (fieldState && fieldState.status === 'loaded') {
+    if (fieldState?.status === 'loaded') {
       const options = fieldState.options || [];
       const optionCount = options.length;
 

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -34,4 +34,57 @@ resolver.define('getAllFields', async () => {
   return enrichedFields;
 });
 
+resolver.define('getFieldOptions', async ({ payload }) => {
+  const fieldId = payload?.fieldId;
+  if (!fieldId) {
+    return [];
+  }
+
+  try {
+    const contextResponse = await api
+      .asApp()
+      .requestJira(route`/rest/api/3/field/${fieldId}/context?maxResults=50`, {
+        headers: { Accept: 'application/json' },
+      });
+
+    if (contextResponse.ok === false) {
+      return [];
+    }
+
+    const contextData = await contextResponse.json();
+    const contexts = contextData?.values || [];
+    const optionValues = [];
+
+    for (const context of contexts) {
+      const contextId = context?.id;
+      if (!contextId) {
+        continue;
+      }
+
+      const optionResponse = await api
+        .asApp()
+        .requestJira(route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`, {
+          headers: { Accept: 'application/json' },
+        });
+
+      if (optionResponse.ok === false) {
+        continue;
+      }
+
+      const optionData = await optionResponse.json();
+      const contextOptions = optionData?.values || [];
+
+      for (const option of contextOptions) {
+        if (option?.value) {
+          optionValues.push(option.value);
+        }
+      }
+    }
+
+    return Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+  } catch (error) {
+    return [];
+  }
+});
+
 export const handler = resolver.getDefinitions();

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -2,6 +2,117 @@ import Resolver from '@forge/resolver';
 import api, { route } from '@forge/api';
 
 const resolver = new Resolver();
+const JSON_HEADERS = { Accept: 'application/json' };
+
+const requestJiraAsApp = (path) => {
+  return api.asApp().requestJira(path, {
+    headers: JSON_HEADERS,
+  });
+};
+
+const getResponseBodySafely = async (response) => {
+  try {
+    return await response.text();
+  } catch {
+    return '<unavailable>';
+  }
+};
+
+const logFailedResponse = async (prefix, response) => {
+  const responseText = await getResponseBodySafely(response);
+  console.error(`${prefix} status=${response.status} body=${responseText}`);
+};
+
+const getUniqueSortedOptions = (values) => {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+};
+
+const fetchFieldContexts = async (fieldId) => {
+  const contextResponse = await requestJiraAsApp(
+    route`/rest/api/3/field/${fieldId}/context?maxResults=50`
+  );
+
+  if (!contextResponse.ok) {
+    await logFailedResponse(
+      `[getFieldOptions] context request failed for fieldId=${fieldId}`,
+      contextResponse
+    );
+    return [];
+  }
+
+  const contextData = await contextResponse.json();
+  const contexts = contextData?.values || [];
+  console.log(`[getFieldOptions] fieldId=${fieldId} contexts=${contexts.length}`);
+  return contexts;
+};
+
+const fetchOptionsForContext = async (fieldId, contextId) => {
+  const optionResponse = await requestJiraAsApp(
+    route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`
+  );
+
+  if (!optionResponse.ok) {
+    await logFailedResponse(
+      `[getFieldOptions] option request failed for fieldId=${fieldId} contextId=${contextId}`,
+      optionResponse
+    );
+    return [];
+  }
+
+  const optionData = await optionResponse.json();
+  const contextOptions = optionData?.values || [];
+  return contextOptions.map((option) => option?.value).filter(Boolean);
+};
+
+const fetchOptionsFromContexts = async (fieldId, contexts) => {
+  const optionValues = [];
+
+  for (const context of contexts) {
+    const contextId = context?.id;
+    if (!contextId) {
+      continue;
+    }
+
+    const values = await fetchOptionsForContext(fieldId, contextId);
+    optionValues.push(...values);
+  }
+
+  return getUniqueSortedOptions(optionValues);
+};
+
+const fetchOptionsFromCreateMeta = async (fieldId, projectId) => {
+  const createMetaResponse = await requestJiraAsApp(
+    route`/rest/api/3/issue/createmeta?projectIds=${projectId}&expand=projects.issuetypes.fields`
+  );
+
+  if (!createMetaResponse.ok) {
+    await logFailedResponse(
+      `[getFieldOptions] createmeta fallback failed for fieldId=${fieldId} projectId=${projectId}`,
+      createMetaResponse
+    );
+    return [];
+  }
+
+  const createMetaData = await createMetaResponse.json();
+  const projects = createMetaData?.projects || [];
+  const metaValues = [];
+
+  for (const project of projects) {
+    const issueTypes = project?.issuetypes || [];
+    for (const issueType of issueTypes) {
+      const fieldMeta = issueType?.fields?.[fieldId];
+      const allowedValues = fieldMeta?.allowedValues || [];
+      for (const item of allowedValues) {
+        const value = item?.value || item?.name;
+        if (value) {
+          metaValues.push(value);
+        }
+      }
+    }
+  }
+
+  return getUniqueSortedOptions(metaValues);
+};
 
 resolver.define('getAllFields', async () => {
   // Step 1: Get all fields
@@ -42,101 +153,17 @@ resolver.define('getFieldOptions', async ({ payload }) => {
   }
 
   try {
-    const requestJiraWithFallback = async (path) => {
-      try {
-        return await api.asUser().requestJira(path, {
-          headers: { Accept: 'application/json' },
-        });
-      } catch (error) {
-        return api.asApp().requestJira(path, {
-          headers: { Accept: 'application/json' },
-        });
-      }
-    };
-
     console.log(`[getFieldOptions] fetching options for fieldId=${fieldId}`);
-    const contextResponse = await requestJiraWithFallback(
-      route`/rest/api/3/field/${fieldId}/context?maxResults=50`
-    );
-
-    let contexts = [];
-    if (contextResponse.ok === false) {
-      const responseText = await contextResponse.text();
-      console.error(
-        `[getFieldOptions] context request failed for fieldId=${fieldId} status=${contextResponse.status} body=${responseText}`
-      );
-    } else {
-      const contextData = await contextResponse.json();
-      contexts = contextData?.values || [];
-      console.log(`[getFieldOptions] fieldId=${fieldId} contexts=${contexts.length}`);
-    }
-    const optionValues = [];
-
-    for (const context of contexts) {
-      const contextId = context?.id;
-      if (!contextId) {
-        continue;
-      }
-
-      const optionResponse = await requestJiraWithFallback(
-        route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`
-      );
-
-      if (optionResponse.ok === false) {
-        const responseText = await optionResponse.text();
-        console.error(
-          `[getFieldOptions] option request failed for fieldId=${fieldId} contextId=${contextId} status=${optionResponse.status} body=${responseText}`
-        );
-        continue;
-      }
-
-      const optionData = await optionResponse.json();
-      const contextOptions = optionData?.values || [];
-
-      for (const option of contextOptions) {
-        if (option?.value) {
-          optionValues.push(option.value);
-        }
-      }
-    }
-
-    let result = Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+    const contexts = await fetchFieldContexts(fieldId);
+    let result = await fetchOptionsFromContexts(fieldId, contexts);
 
     // Team-managed fields can return empty context options; use create metadata as fallback.
     if (result.length === 0 && projectId) {
-      const createMetaResponse = await requestJiraWithFallback(
-        route`/rest/api/3/issue/createmeta?projectIds=${projectId}&expand=projects.issuetypes.fields`
-      );
-
-      if (createMetaResponse.ok) {
-        const createMetaData = await createMetaResponse.json();
-        const projects = createMetaData?.projects || [];
-        const metaValues = [];
-
-        for (const project of projects) {
-          const issueTypes = project?.issuetypes || [];
-          for (const issueType of issueTypes) {
-            const fieldMeta = issueType?.fields?.[fieldId];
-            const allowedValues = fieldMeta?.allowedValues || [];
-            for (const item of allowedValues) {
-              const value = item?.value || item?.name;
-              if (value) {
-                metaValues.push(value);
-              }
-            }
-          }
-        }
-
-        if (metaValues.length > 0) {
-          result = Array.from(new Set(metaValues)).sort((a, b) => a.localeCompare(b));
-          console.log(
-            `[getFieldOptions] fieldId=${fieldId} populated from createmeta fallback optionCount=${result.length}`
-          );
-        }
-      } else {
-        const responseText = await createMetaResponse.text();
-        console.error(
-          `[getFieldOptions] createmeta fallback failed for fieldId=${fieldId} projectId=${projectId} status=${createMetaResponse.status} body=${responseText}`
+      const fallbackResult = await fetchOptionsFromCreateMeta(fieldId, projectId);
+      if (fallbackResult.length > 0) {
+        result = fallbackResult;
+        console.log(
+          `[getFieldOptions] fieldId=${fieldId} populated from createmeta fallback optionCount=${result.length}`
         );
       }
     }

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -41,12 +41,22 @@ resolver.define('getFieldOptions', async ({ payload }) => {
   }
 
   try {
+    const requestJiraWithFallback = async (path) => {
+      try {
+        return await api.asUser().requestJira(path, {
+          headers: { Accept: 'application/json' },
+        });
+      } catch (error) {
+        return api.asApp().requestJira(path, {
+          headers: { Accept: 'application/json' },
+        });
+      }
+    };
+
     console.log(`[getFieldOptions] fetching options for fieldId=${fieldId}`);
-    const contextResponse = await api
-      .asApp()
-      .requestJira(route`/rest/api/3/field/${fieldId}/context?maxResults=50`, {
-        headers: { Accept: 'application/json' },
-      });
+    const contextResponse = await requestJiraWithFallback(
+      route`/rest/api/3/field/${fieldId}/context?maxResults=50`
+    );
 
     if (contextResponse.ok === false) {
       const responseText = await contextResponse.text();
@@ -67,11 +77,9 @@ resolver.define('getFieldOptions', async ({ payload }) => {
         continue;
       }
 
-      const optionResponse = await api
-        .asApp()
-        .requestJira(route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`, {
-          headers: { Accept: 'application/json' },
-        });
+      const optionResponse = await requestJiraWithFallback(
+        route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`
+      );
 
       if (optionResponse.ok === false) {
         const responseText = await optionResponse.text();

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -36,6 +36,7 @@ resolver.define('getAllFields', async () => {
 
 resolver.define('getFieldOptions', async ({ payload }) => {
   const fieldId = payload?.fieldId;
+  const projectId = payload?.projectId;
   if (!fieldId) {
     return [];
   }
@@ -99,7 +100,47 @@ resolver.define('getFieldOptions', async ({ payload }) => {
       }
     }
 
-    const result = Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+    let result = Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+
+    // Team-managed fields can return empty context options; use create metadata as fallback.
+    if (result.length === 0 && projectId) {
+      const createMetaResponse = await requestJiraWithFallback(
+        route`/rest/api/3/issue/createmeta?projectIds=${projectId}&expand=projects.issuetypes.fields`
+      );
+
+      if (createMetaResponse.ok) {
+        const createMetaData = await createMetaResponse.json();
+        const projects = createMetaData?.projects || [];
+        const metaValues = [];
+
+        for (const project of projects) {
+          const issueTypes = project?.issuetypes || [];
+          for (const issueType of issueTypes) {
+            const fieldMeta = issueType?.fields?.[fieldId];
+            const allowedValues = fieldMeta?.allowedValues || [];
+            for (const item of allowedValues) {
+              const value = item?.value || item?.name;
+              if (value) {
+                metaValues.push(value);
+              }
+            }
+          }
+        }
+
+        if (metaValues.length > 0) {
+          result = Array.from(new Set(metaValues)).sort((a, b) => a.localeCompare(b));
+          console.log(
+            `[getFieldOptions] fieldId=${fieldId} populated from createmeta fallback optionCount=${result.length}`
+          );
+        }
+      } else {
+        const responseText = await createMetaResponse.text();
+        console.error(
+          `[getFieldOptions] createmeta fallback failed for fieldId=${fieldId} projectId=${projectId} status=${createMetaResponse.status} body=${responseText}`
+        );
+      }
+    }
+
     console.log(`[getFieldOptions] fieldId=${fieldId} optionCount=${result.length}`);
     return result;
   } catch (error) {

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -41,6 +41,7 @@ resolver.define('getFieldOptions', async ({ payload }) => {
   }
 
   try {
+    console.log(`[getFieldOptions] fetching options for fieldId=${fieldId}`);
     const contextResponse = await api
       .asApp()
       .requestJira(route`/rest/api/3/field/${fieldId}/context?maxResults=50`, {
@@ -48,11 +49,16 @@ resolver.define('getFieldOptions', async ({ payload }) => {
       });
 
     if (contextResponse.ok === false) {
+      const responseText = await contextResponse.text();
+      console.error(
+        `[getFieldOptions] context request failed for fieldId=${fieldId} status=${contextResponse.status} body=${responseText}`
+      );
       return [];
     }
 
     const contextData = await contextResponse.json();
     const contexts = contextData?.values || [];
+    console.log(`[getFieldOptions] fieldId=${fieldId} contexts=${contexts.length}`);
     const optionValues = [];
 
     for (const context of contexts) {
@@ -68,6 +74,10 @@ resolver.define('getFieldOptions', async ({ payload }) => {
         });
 
       if (optionResponse.ok === false) {
+        const responseText = await optionResponse.text();
+        console.error(
+          `[getFieldOptions] option request failed for fieldId=${fieldId} contextId=${contextId} status=${optionResponse.status} body=${responseText}`
+        );
         continue;
       }
 
@@ -81,8 +91,11 @@ resolver.define('getFieldOptions', async ({ payload }) => {
       }
     }
 
-    return Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+    const result = Array.from(new Set(optionValues)).sort((a, b) => a.localeCompare(b));
+    console.log(`[getFieldOptions] fieldId=${fieldId} optionCount=${result.length}`);
+    return result;
   } catch (error) {
+    console.error(`[getFieldOptions] unexpected error for fieldId=${fieldId}: ${error?.message || error}`);
     return [];
   }
 });

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -59,17 +59,17 @@ resolver.define('getFieldOptions', async ({ payload }) => {
       route`/rest/api/3/field/${fieldId}/context?maxResults=50`
     );
 
+    let contexts = [];
     if (contextResponse.ok === false) {
       const responseText = await contextResponse.text();
       console.error(
         `[getFieldOptions] context request failed for fieldId=${fieldId} status=${contextResponse.status} body=${responseText}`
       );
-      return [];
+    } else {
+      const contextData = await contextResponse.json();
+      contexts = contextData?.values || [];
+      console.log(`[getFieldOptions] fieldId=${fieldId} contexts=${contexts.length}`);
     }
-
-    const contextData = await contextResponse.json();
-    const contexts = contextData?.values || [];
-    console.log(`[getFieldOptions] fieldId=${fieldId} contexts=${contexts.length}`);
     const optionValues = [];
 
     for (const context of contexts) {

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -340,7 +340,10 @@ describe('Jira Fields Viewer App', () => {
         expect(screen.getByText('Low, Medium, High')).toBeInTheDocument();
       });
 
-      expect(invoke).toHaveBeenCalledWith('getFieldOptions', { fieldId: 'customfield_10010' });
+      expect(invoke).toHaveBeenCalledWith(
+        'getFieldOptions',
+        expect.objectContaining({ fieldId: 'customfield_10010' })
+      );
     });
   });
 });

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -54,11 +54,6 @@ vi.mock('@forge/react', () => ({
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
   Tooltip: ({ text, children }) => <span data-tooltip={text}>{children}</span>,
-  Button: ({ text, onClick, disabled }) => (
-    <button type="button" disabled={disabled} onClick={onClick}>
-      {text}
-    </button>
-  ),
 }));
 
 // Import the App component
@@ -338,9 +333,6 @@ describe('Jira Fields Viewer App', () => {
       });
 
       render(<App />);
-
-      const loadButton = await screen.findByRole('button', { name: 'option (show options)' });
-      fireEvent.click(loadButton);
 
       await waitFor(() => {
         expect(screen.getByText('option (3)')).toBeInTheDocument();

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -53,6 +53,12 @@ vi.mock('@forge/react', () => ({
   Tab: ({ children }) => <button data-testid="tab">{children}</button>,
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
+  Tooltip: ({ text, children }) => <span data-tooltip={text}>{children}</span>,
+  Pressable: ({ onPress, ariaLabel, children }) => (
+    <button type="button" aria-label={ariaLabel} onClick={onPress}>
+      {children}
+    </button>
+  ),
 }));
 
 // Import the App component
@@ -307,6 +313,40 @@ describe('Jira Fields Viewer App', () => {
       await waitFor(() => {
         expect(screen.getByText('Company Managed Fields')).toBeInTheDocument();
       });
+    });
+
+    test('should load and display option count for selectable fields', async () => {
+      const selectableFields = [
+        {
+          id: 'customfield_10010',
+          name: 'Risk Level',
+          key: 'customfield_10010',
+          schema: { type: 'option', custom: 'com.atlassian.jira.plugin.system.customfieldtypes:select' },
+        },
+      ];
+
+      invoke.mockImplementation((fnName) => {
+        if (fnName === 'getAllFields') {
+          return Promise.resolve(selectableFields);
+        }
+
+        if (fnName === 'getFieldOptions') {
+          return Promise.resolve(['Low', 'Medium', 'High']);
+        }
+
+        return Promise.resolve([]);
+      });
+
+      render(<App />);
+
+      const loadButton = await screen.findByRole('button', { name: 'Load options for Risk Level' });
+      fireEvent.click(loadButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('option (3)')).toBeInTheDocument();
+      });
+
+      expect(invoke).toHaveBeenCalledWith('getFieldOptions', { fieldId: 'customfield_10010' });
     });
   });
 });

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -54,9 +54,9 @@ vi.mock('@forge/react', () => ({
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
   Tooltip: ({ text, children }) => <span data-tooltip={text}>{children}</span>,
-  Pressable: ({ onPress, ariaLabel, children }) => (
-    <button type="button" aria-label={ariaLabel} onClick={onPress}>
-      {children}
+  Button: ({ text, onClick, disabled }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>
+      {text}
     </button>
   ),
 }));
@@ -339,7 +339,7 @@ describe('Jira Fields Viewer App', () => {
 
       render(<App />);
 
-      const loadButton = await screen.findByRole('button', { name: 'Load options for Risk Level' });
+      const loadButton = await screen.findByRole('button', { name: 'option (show options)' });
       fireEvent.click(loadButton);
 
       await waitFor(() => {

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -269,6 +269,7 @@ describe('Jira Fields Viewer App', () => {
         expect(screen.getAllByText('Field Name').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Field ID').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Field Type').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Options').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Project Name').length).toBeGreaterThan(0);
       });
     });
@@ -336,6 +337,7 @@ describe('Jira Fields Viewer App', () => {
 
       await waitFor(() => {
         expect(screen.getByText('option (3)')).toBeInTheDocument();
+        expect(screen.getByText('Low, Medium, High')).toBeInTheDocument();
       });
 
       expect(invoke).toHaveBeenCalledWith('getFieldOptions', { fieldId: 'customfield_10010' });

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -53,7 +53,7 @@ vi.mock('@forge/react', () => ({
   Tab: ({ children }) => <button data-testid="tab">{children}</button>,
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
-  Tooltip: ({ text, children }) => <span data-tooltip={text}>{children}</span>,
+  Tooltip: React.Fragment,
 }));
 
 // Import the App component
@@ -344,6 +344,36 @@ describe('Jira Fields Viewer App', () => {
         'getFieldOptions',
         expect.objectContaining({ fieldId: 'customfield_10010' })
       );
+    });
+
+    test('should show unavailable state when selectable field options fail to load', async () => {
+      const selectableFields = [
+        {
+          id: 'customfield_10010',
+          name: 'Risk Level',
+          key: 'customfield_10010',
+          schema: { type: 'option', custom: 'com.atlassian.jira.plugin.system.customfieldtypes:select' },
+        },
+      ];
+
+      invoke.mockImplementation((fnName) => {
+        if (fnName === 'getAllFields') {
+          return Promise.resolve(selectableFields);
+        }
+
+        if (fnName === 'getFieldOptions') {
+          return Promise.reject(new Error('Failed to load options'));
+        }
+
+        return Promise.resolve([]);
+      });
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText('option (options unavailable)')).toBeInTheDocument();
+        expect(screen.getByText('Options unavailable')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -321,5 +321,38 @@ describe('Resolvers', () => {
 
       expect(result).toEqual(['Option A', 'Option B']);
     });
+
+    it('should use create metadata fallback when context endpoint returns 404', async () => {
+      mockRequestJira
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          text: async () => '{"errorMessages":["The custom field was not found."],"errors":{}}',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            projects: [
+              {
+                issuetypes: [
+                  {
+                    fields: {
+                      customfield_10124: {
+                        allowedValues: [{ value: 'Alpha' }, { value: 'Beta' }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+        });
+
+      const result = await handler.getFieldOptions({
+        payload: { fieldId: 'customfield_10124', projectId: '10001' },
+      });
+
+      expect(result).toEqual(['Alpha', 'Beta']);
+    });
   });
 });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -6,7 +6,6 @@ vi.mock('@forge/api', () => ({
   __esModule: true,
   default: {
     asApp: vi.fn(),
-    asUser: vi.fn(),
   },
   route: vi.fn(),
 }));
@@ -45,9 +44,6 @@ describe('Resolvers', () => {
     // Setup the mock chain
     mockRequestJira = vi.fn();
     api.asApp = vi.fn().mockReturnValue({
-      requestJira: mockRequestJira,
-    });
-    api.asUser = vi.fn().mockReturnValue({
       requestJira: mockRequestJira,
     });
     
@@ -252,20 +248,56 @@ describe('Resolvers', () => {
   });
 
   describe('getFieldOptions', () => {
+    const okJsonResponse = (body) => ({
+      ok: true,
+      json: async () => body,
+    });
+
+    const contextResponse = (...ids) => okJsonResponse({ values: ids.map((id) => ({ id })) });
+
+    const optionResponse = (...values) => {
+      return okJsonResponse({ values: values.map((value) => ({ value })) });
+    };
+
+    const createMetaResponse = (fieldId, ...values) => {
+      return okJsonResponse({
+        projects: [
+          {
+            issuetypes: [
+              {
+                fields: {
+                  [fieldId]: {
+                    allowedValues: values.map((value) => ({ value })),
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    };
+
+    const fieldNotFoundResponse = () => ({
+      ok: false,
+      status: 404,
+      text: async () => '{"errorMessages":["The custom field was not found."],"errors":{}}',
+    });
+
+    it('should request Jira with app context', async () => {
+      mockRequestJira.mockResolvedValueOnce(contextResponse());
+
+      const result = await handler.getFieldOptions({ payload: { fieldId: 'customfield_10000' } });
+
+      expect(result).toEqual([]);
+      expect(api.asApp).toHaveBeenCalled();
+      expect(mockRequestJira).toHaveBeenCalledTimes(1);
+    });
+
     it('should return de-duplicated sorted options across contexts', async () => {
       mockRequestJira
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ values: [{ id: '10' }, { id: '20' }] }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ values: [{ value: 'Beta' }, { value: 'Alpha' }] }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ values: [{ value: 'Alpha' }, { value: 'Gamma' }] }),
-        });
+        .mockResolvedValueOnce(contextResponse('10', '20'))
+        .mockResolvedValueOnce(optionResponse('Beta', 'Alpha'))
+        .mockResolvedValueOnce(optionResponse('Alpha', 'Gamma'));
 
       const result = await handler.getFieldOptions({ payload: { fieldId: 'customfield_10000' } });
 
@@ -288,32 +320,9 @@ describe('Resolvers', () => {
 
     it('should use create metadata fallback when context options are empty', async () => {
       mockRequestJira
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ values: [{ id: '10' }] }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ values: [] }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            projects: [
-              {
-                issuetypes: [
-                  {
-                    fields: {
-                      customfield_10124: {
-                        allowedValues: [{ value: 'Option A' }, { value: 'Option B' }],
-                      },
-                    },
-                  },
-                ],
-              },
-            ],
-          }),
-        });
+        .mockResolvedValueOnce(contextResponse('10'))
+        .mockResolvedValueOnce(optionResponse())
+        .mockResolvedValueOnce(createMetaResponse('customfield_10124', 'Option A', 'Option B'));
 
       const result = await handler.getFieldOptions({
         payload: { fieldId: 'customfield_10124', projectId: '10001' },
@@ -324,29 +333,8 @@ describe('Resolvers', () => {
 
     it('should use create metadata fallback when context endpoint returns 404', async () => {
       mockRequestJira
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          text: async () => '{"errorMessages":["The custom field was not found."],"errors":{}}',
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            projects: [
-              {
-                issuetypes: [
-                  {
-                    fields: {
-                      customfield_10124: {
-                        allowedValues: [{ value: 'Alpha' }, { value: 'Beta' }],
-                      },
-                    },
-                  },
-                ],
-              },
-            ],
-          }),
-        });
+        .mockResolvedValueOnce(fieldNotFoundResponse())
+        .mockResolvedValueOnce(createMetaResponse('customfield_10124', 'Alpha', 'Beta'));
 
       const result = await handler.getFieldOptions({
         payload: { fieldId: 'customfield_10124', projectId: '10001' },

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -47,7 +47,9 @@ describe('Resolvers', () => {
       requestJira: mockRequestJira,
     });
     
-    route.mockImplementation((strings, ...values) => strings.join(''));
+    route.mockImplementation((strings, ...values) =>
+      strings.reduce((acc, str, idx) => acc + str + (values[idx] ?? ''), '')
+    );
   });
 
   describe('getAllFields', () => {
@@ -242,6 +244,42 @@ describe('Resolvers', () => {
       result.forEach(field => {
         expect(field.projectName).toBe('Shared Project');
       });
+    });
+  });
+
+  describe('getFieldOptions', () => {
+    it('should return de-duplicated sorted options across contexts', async () => {
+      mockRequestJira
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ values: [{ id: '10' }, { id: '20' }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ values: [{ value: 'Beta' }, { value: 'Alpha' }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ values: [{ value: 'Alpha' }, { value: 'Gamma' }] }),
+        });
+
+      const result = await handler.getFieldOptions({ payload: { fieldId: 'customfield_10000' } });
+
+      expect(result).toEqual(['Alpha', 'Beta', 'Gamma']);
+      expect(mockRequestJira).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return empty array when field id is missing', async () => {
+      const result = await handler.getFieldOptions({ payload: {} });
+      expect(result).toEqual([]);
+      expect(mockRequestJira).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array when Jira API throws', async () => {
+      mockRequestJira.mockRejectedValueOnce(new Error('Jira unavailable'));
+
+      const result = await handler.getFieldOptions({ payload: { fieldId: 'customfield_10001' } });
+      expect(result).toEqual([]);
     });
   });
 });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -285,5 +285,41 @@ describe('Resolvers', () => {
       const result = await handler.getFieldOptions({ payload: { fieldId: 'customfield_10001' } });
       expect(result).toEqual([]);
     });
+
+    it('should use create metadata fallback when context options are empty', async () => {
+      mockRequestJira
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ values: [{ id: '10' }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ values: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            projects: [
+              {
+                issuetypes: [
+                  {
+                    fields: {
+                      customfield_10124: {
+                        allowedValues: [{ value: 'Option A' }, { value: 'Option B' }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+        });
+
+      const result = await handler.getFieldOptions({
+        payload: { fieldId: 'customfield_10124', projectId: '10001' },
+      });
+
+      expect(result).toEqual(['Option A', 'Option B']);
+    });
   });
 });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -6,6 +6,7 @@ vi.mock('@forge/api', () => ({
   __esModule: true,
   default: {
     asApp: vi.fn(),
+    asUser: vi.fn(),
   },
   route: vi.fn(),
 }));
@@ -44,6 +45,9 @@ describe('Resolvers', () => {
     // Setup the mock chain
     mockRequestJira = vi.fn();
     api.asApp = vi.fn().mockReturnValue({
+      requestJira: mockRequestJira,
+    });
+    api.asUser = vi.fn().mockReturnValue({
       requestJira: mockRequestJira,
     });
     


### PR DESCRIPTION
## Summary
- add getFieldOptions resolver to fetch and merge custom field options across contexts
- render selectable field types as interactive cells with tooltip overlay and lazy option loading
- show option counts in the field type cell after load
- add read:field.option:jira scope for option endpoint access
- extend resolver/frontend tests for new option behavior

## Notes
- deploy is currently blocked by Forge lint scope requirement for /field/{fieldId}/context (needs manage:jira-configuration)
