### PR TITLE
Simplify Jira field options flow

### DIFF
--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -5,16 +5,19 @@ on:
     branches: [ '*' ]
   workflow_dispatch: # allows manual runs from the GitHub UI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/deploy-forge.yml
+++ b/.github/workflows/deploy-forge.yml
@@ -2,7 +2,7 @@ name: Deploy Atlassian Forge App
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
   workflow_dispatch: # allows manual runs from the GitHub UI
 
 env:

--- a/atlassian-jira-fields-viewer/manifest.yml
+++ b/atlassian-jira-fields-viewer/manifest.yml
@@ -25,3 +25,5 @@ permissions:
   #https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/
     - read:jira-work
     - read:field:jira
+    - read:field.option:jira
+    - manage:jira-configuration

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -9,6 +9,7 @@ import ForgeReconciler, {
   TabPanel,
   Box,
   Tooltip,
+  Text,
 } from '@forge/react';
 import { invoke } from '@forge/bridge';
 
@@ -42,15 +43,12 @@ export const App = () => {
     });
   };
 
-  const formatOptionValues = (options, limit) => {
+  const formatOptionValues = (options) => {
     if (!options.length) {
       return null;
     }
 
-    const visibleOptions = options.slice(0, limit);
-    const hiddenCount = options.length - visibleOptions.length;
-    const optionText = visibleOptions.join(', ');
-    return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
+    return options.join(', ');
   };
 
   const getOptionDisplayModel = (field) => {
@@ -61,18 +59,17 @@ export const App = () => {
     const fieldType = field.schema?.type || 'N/A';
     if (field.optionInfo.status === 'error') {
       return {
-        typeText: `${fieldType} (options unavailable)`,
+        typeText: fieldType,
         optionsText: 'Options unavailable',
         tooltipText: 'Unable to load options',
       };
     }
 
     const options = field.optionInfo.options || [];
-    const optionCount = options.length;
     return {
-      typeText: `${fieldType} (${optionCount})`,
-      optionsText: formatOptionValues(options, 3) || 'No options',
-      tooltipText: formatOptionValues(options, 20) || 'No options found for this field',
+      typeText: fieldType,
+      optionsText: formatOptionValues(options) || 'No options',
+      tooltipText: formatOptionValues(options) || 'No options found for this field',
     };
   };
 
@@ -95,7 +92,10 @@ export const App = () => {
               field.schema?.type || 'N/A'
             ),
           },
-          { key: 'options', content: optionDisplayModel?.optionsText || '-' },
+          {
+            key: 'options',
+            content: <Text size="small">{optionDisplayModel?.optionsText || '-'}</Text>,
+          },
           { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
         ],
       };

--- a/atlassian-jira-fields-viewer/src/frontend/index.jsx
+++ b/atlassian-jira-fields-viewer/src/frontend/index.jsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import ForgeReconciler, { Label, DynamicTable, Textfield, Tabs, TabList, Tab, TabPanel, Box} from '@forge/react';
+import ForgeReconciler, {
+  Label,
+  DynamicTable,
+  Textfield,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
+  Box,
+  Tooltip,
+} from '@forge/react';
 import { invoke } from '@forge/bridge';
 
 export const App = () => {
@@ -19,11 +29,10 @@ export const App = () => {
       { key: 'name', content: 'Field Name' },
       { key: 'key', content: 'Field ID' },
       { key: 'type', content: 'Field Type' },
+      { key: 'options', content: 'Options' },
       { key: 'projectName', content: 'Project Name' },
     ],
   };
-
-  // --- 🔁 Common Utility Functions ---
 
   const sortFieldsByName = (fields) => {
     return [...fields].sort((a, b) => {
@@ -33,17 +42,64 @@ export const App = () => {
     });
   };
 
+  const formatOptionValues = (options, limit) => {
+    if (!options.length) {
+      return null;
+    }
+
+    const visibleOptions = options.slice(0, limit);
+    const hiddenCount = options.length - visibleOptions.length;
+    const optionText = visibleOptions.join(', ');
+    return hiddenCount > 0 ? `${optionText} (+${hiddenCount} more)` : optionText;
+  };
+
+  const getOptionDisplayModel = (field) => {
+    if (!field?.optionInfo) {
+      return null;
+    }
+
+    const fieldType = field.schema?.type || 'N/A';
+    if (field.optionInfo.status === 'error') {
+      return {
+        typeText: `${fieldType} (options unavailable)`,
+        optionsText: 'Options unavailable',
+        tooltipText: 'Unable to load options',
+      };
+    }
+
+    const options = field.optionInfo.options || [];
+    const optionCount = options.length;
+    return {
+      typeText: `${fieldType} (${optionCount})`,
+      optionsText: formatOptionValues(options, 3) || 'No options',
+      tooltipText: formatOptionValues(options, 20) || 'No options found for this field',
+    };
+  };
+
   const mapFieldsToRows = (fields) => {
-    return fields.map((field, index) => ({
-      key: field.id || `row-${index}`,
-      cells: [
-        { key: 'number', content: index + 1 },
-        { key: 'name', content: field.name },
-        { key: 'key', content: field.key },
-        { key: 'type', content: field.schema?.type || 'N/A' },
-        { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
-      ],
-    }));
+    return fields.map((field, index) => {
+      const optionDisplayModel = getOptionDisplayModel(field);
+      return {
+        key: field.id || `row-${index}`,
+        cells: [
+          { key: 'number', content: index + 1 },
+          { key: 'name', content: field.name },
+          { key: 'key', content: field.key },
+          {
+            key: 'type',
+            content: optionDisplayModel ? (
+              <Tooltip text={optionDisplayModel.tooltipText}>
+                {optionDisplayModel.typeText}
+              </Tooltip>
+            ) : (
+              field.schema?.type || 'N/A'
+            ),
+          },
+          { key: 'options', content: optionDisplayModel?.optionsText || '-' },
+          { key: 'projectName', content: field.projectName || 'Company Managed Fields' },
+        ],
+      };
+    });
   };
 
   const getDuplicateFields = (fields) => {
@@ -62,8 +118,6 @@ export const App = () => {
     return fields.filter(field => duplicateNames.has(field.name));
   };
 
-  // --- 📦 Field Processing ---
-
   const filteredFields = fields.filter(field =>
     field.name?.toLowerCase().includes(filter.toLowerCase())
   );
@@ -74,7 +128,6 @@ export const App = () => {
   const sortedDuplicateFields = sortFieldsByName(getDuplicateFields(fields));
   const duplicateRows = mapFieldsToRows(sortedDuplicateFields);
 
-  // --- 💡 UI Rendering ---
   return (
     <>
       <Tabs id="default">

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -101,6 +101,10 @@ const fetchFieldContexts = async (fieldId) => {
   );
 
   if (!contextResponse.ok) {
+    if (contextResponse.status === 404) {
+      // Some custom fields are not available in the contexts API; treat as expected.
+      return [];
+    }
     await logFailedResponse(
       `[getAllFields] context request failed for fieldId=${fieldId}`,
       contextResponse

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -2,36 +2,182 @@ import Resolver from '@forge/resolver';
 import api, { route } from '@forge/api';
 
 const resolver = new Resolver();
+const JSON_HEADERS = { Accept: 'application/json' };
+
+const requestJiraAsApp = (path) => {
+  return api.asApp().requestJira(path, { headers: JSON_HEADERS });
+};
+
+const getResponseBodySafely = async (response) => {
+  try {
+    return await response.text();
+  } catch {
+    return '<unavailable>';
+  }
+};
+
+const logFailedResponse = async (prefix, response) => {
+  const responseText = await getResponseBodySafely(response);
+  console.error(`${prefix} status=${response.status} body=${responseText}`);
+};
+
+const getUniqueSortedOptions = (values) => {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+};
+
+const isOptionBasedField = (field) => {
+  const type = field?.schema?.type?.toLowerCase?.() || '';
+  const items = field?.schema?.items?.toLowerCase?.() || '';
+  const custom = field?.schema?.custom?.toLowerCase?.() || '';
+
+  return (
+    type === 'option' ||
+    items === 'option' ||
+    custom.includes('select') ||
+    custom.includes('checkbox') ||
+    custom.includes('radio') ||
+    custom.includes('cascading')
+  );
+};
+
+const fetchFieldContexts = async (fieldId) => {
+  const contextResponse = await requestJiraAsApp(
+    route`/rest/api/3/field/${fieldId}/context?maxResults=50`
+  );
+
+  if (!contextResponse.ok) {
+    await logFailedResponse(
+      `[getAllFields] context request failed for fieldId=${fieldId}`,
+      contextResponse
+    );
+    return [];
+  }
+
+  const contextData = await contextResponse.json();
+  return contextData?.values || [];
+};
+
+const fetchOptionsForContext = async (fieldId, contextId) => {
+  const optionResponse = await requestJiraAsApp(
+    route`/rest/api/3/field/${fieldId}/context/${contextId}/option?maxResults=100`
+  );
+
+  if (!optionResponse.ok) {
+    await logFailedResponse(
+      `[getAllFields] option request failed for fieldId=${fieldId} contextId=${contextId}`,
+      optionResponse
+    );
+    return [];
+  }
+
+  const optionData = await optionResponse.json();
+  const contextOptions = optionData?.values || [];
+  return contextOptions.map((option) => option?.value).filter(Boolean);
+};
+
+const fetchOptionsFromContexts = async (fieldId, contexts) => {
+  const optionValues = [];
+
+  for (const context of contexts) {
+    const contextId = context?.id;
+    if (!contextId) {
+      continue;
+    }
+
+    const values = await fetchOptionsForContext(fieldId, contextId);
+    optionValues.push(...values);
+  }
+
+  return getUniqueSortedOptions(optionValues);
+};
+
+const fetchOptionsFromCreateMeta = async (fieldId, projectId) => {
+  const createMetaResponse = await requestJiraAsApp(
+    route`/rest/api/3/issue/createmeta?projectIds=${projectId}&expand=projects.issuetypes.fields`
+  );
+
+  if (!createMetaResponse.ok) {
+    await logFailedResponse(
+      `[getAllFields] createmeta fallback failed for fieldId=${fieldId} projectId=${projectId}`,
+      createMetaResponse
+    );
+    return [];
+  }
+
+  const createMetaData = await createMetaResponse.json();
+  const projects = createMetaData?.projects || [];
+  const metaValues = [];
+
+  for (const project of projects) {
+    const issueTypes = project?.issuetypes || [];
+    for (const issueType of issueTypes) {
+      const fieldMeta = issueType?.fields?.[fieldId];
+      const allowedValues = fieldMeta?.allowedValues || [];
+      for (const item of allowedValues) {
+        const value = item?.value || item?.name;
+        if (value) {
+          metaValues.push(value);
+        }
+      }
+    }
+  }
+
+  return getUniqueSortedOptions(metaValues);
+};
+
+const fetchFieldOptionInfo = async (field) => {
+  const fieldId = field?.id;
+  const projectId = field?.scope?.project?.id;
+
+  if (!fieldId || !isOptionBasedField(field)) {
+    return null;
+  }
+
+  try {
+    const contexts = await fetchFieldContexts(fieldId);
+    let options = await fetchOptionsFromContexts(fieldId, contexts);
+
+    if (options.length === 0 && projectId) {
+      const fallbackOptions = await fetchOptionsFromCreateMeta(fieldId, projectId);
+      if (fallbackOptions.length > 0) {
+        options = fallbackOptions;
+      }
+    }
+
+    return { status: 'loaded', options };
+  } catch (error) {
+    console.error(`[getAllFields] option fetch failed for fieldId=${fieldId}: ${error?.message || error}`);
+    return { status: 'error', options: [] };
+  }
+};
 
 resolver.define('getAllFields', async () => {
-  // Step 1: Get all fields
-  const fieldResponse = await api.asApp().requestJira(route`/rest/api/3/field`, {
-    headers: { 'Accept': 'application/json' },
-  });
+  const fieldResponse = await requestJiraAsApp(route`/rest/api/3/field`);
   const fields = await fieldResponse.json();
 
-  // Step 2: Get all projects
-  const projectResponse = await api.asApp().requestJira(route`/rest/api/3/project`, {
-    headers: { 'Accept': 'application/json' },
-  });
+  const projectResponse = await requestJiraAsApp(route`/rest/api/3/project`);
   const projects = await projectResponse.json();
 
-  // Step 3: Build map from projectId to projectName
   const projectMap = {};
   for (const project of projects) {
     projectMap[project.id] = project.name;
   }
 
-  // Step 4: Enrich fields with project name if team-managed
-  const enrichedFields = fields.map(field => {
+  const optionInfoByFieldId = {};
+  const optionFields = fields.filter((field) => isOptionBasedField(field) && field?.id);
+
+  for (const field of optionFields) {
+    optionInfoByFieldId[field.id] = await fetchFieldOptionInfo(field);
+  }
+
+  return fields.map((field) => {
     const projectId = field.scope?.project?.id;
     return {
       ...field,
-      projectName: projectId ? projectMap[projectId] || 'Unknown Project' : null
+      projectName: projectId ? projectMap[projectId] || 'Unknown Project' : null,
+      optionInfo: optionInfoByFieldId[field.id] || null,
     };
   });
-
-  return enrichedFields;
 });
 
 export const handler = resolver.getDefinitions();

--- a/atlassian-jira-fields-viewer/src/resolvers/index.js
+++ b/atlassian-jira-fields-viewer/src/resolvers/index.js
@@ -3,9 +3,64 @@ import api, { route } from '@forge/api';
 
 const resolver = new Resolver();
 const JSON_HEADERS = { Accept: 'application/json' };
+const RETRYABLE_STATUSES = new Set([429, 503]);
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 250;
+const MAX_CONCURRENCY = 5;
 
-const requestJiraAsApp = (path) => {
-  return api.asApp().requestJira(path, { headers: JSON_HEADERS });
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const getRetryDelayMs = (response, attempt) => {
+  const retryAfter = response?.headers?.get?.('retry-after');
+  const retryAfterSeconds = Number.parseInt(retryAfter, 10);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * 1000;
+  }
+
+  return INITIAL_RETRY_DELAY_MS * (2 ** attempt);
+};
+
+const requestJiraAsApp = async (path) => {
+  let lastResponse = null;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+    const response = await api.asApp().requestJira(path, { headers: JSON_HEADERS });
+    lastResponse = response;
+
+    if (response.ok || !RETRYABLE_STATUSES.has(response.status) || attempt === MAX_RETRIES) {
+      return response;
+    }
+
+    const delayMs = getRetryDelayMs(response, attempt);
+    console.warn(
+      `[requestJiraAsApp] retrying status=${response.status} attempt=${attempt + 1} delayMs=${delayMs}`
+    );
+    await wait(delayMs);
+  }
+
+  return lastResponse;
+};
+
+const mapWithConcurrency = async (items, worker, maxConcurrency = MAX_CONCURRENCY) => {
+  const results = new Array(items.length);
+  let index = 0;
+
+  const runNext = async () => {
+    const currentIndex = index;
+    if (currentIndex >= items.length) {
+      return;
+    }
+    index += 1;
+    results[currentIndex] = await worker(items[currentIndex], currentIndex);
+    await runNext();
+  };
+
+  const workers = Array.from(
+    { length: Math.min(maxConcurrency, items.length) },
+    () => runNext()
+  );
+  await Promise.all(workers);
+  return results;
 };
 
 const getResponseBodySafely = async (response) => {
@@ -76,19 +131,17 @@ const fetchOptionsForContext = async (fieldId, contextId) => {
 };
 
 const fetchOptionsFromContexts = async (fieldId, contexts) => {
-  const optionValues = [];
-
-  for (const context of contexts) {
-    const contextId = context?.id;
-    if (!contextId) {
-      continue;
-    }
-
-    const values = await fetchOptionsForContext(fieldId, contextId);
-    optionValues.push(...values);
+  const contextIds = contexts.map((context) => context?.id).filter(Boolean);
+  if (!contextIds.length) {
+    return [];
   }
 
-  return getUniqueSortedOptions(optionValues);
+  const optionGroups = await mapWithConcurrency(
+    contextIds,
+    (contextId) => fetchOptionsForContext(fieldId, contextId)
+  );
+
+  return getUniqueSortedOptions(optionGroups.flat());
 };
 
 const fetchOptionsFromCreateMeta = async (fieldId, projectId) => {
@@ -129,7 +182,7 @@ const fetchFieldOptionInfo = async (field) => {
   const fieldId = field?.id;
   const projectId = field?.scope?.project?.id;
 
-  if (!fieldId || !isOptionBasedField(field)) {
+  if (!fieldId) {
     return null;
   }
 
@@ -163,12 +216,11 @@ resolver.define('getAllFields', async () => {
     projectMap[project.id] = project.name;
   }
 
-  const optionInfoByFieldId = {};
   const optionFields = fields.filter((field) => isOptionBasedField(field) && field?.id);
-
-  for (const field of optionFields) {
-    optionInfoByFieldId[field.id] = await fetchFieldOptionInfo(field);
-  }
+  const optionInfos = await mapWithConcurrency(optionFields, (field) => fetchFieldOptionInfo(field));
+  const optionInfoByFieldId = Object.fromEntries(
+    optionFields.map((field, idx) => [field.id, optionInfos[idx]])
+  );
 
   return fields.map((field) => {
     const projectId = field.scope?.project?.id;

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -54,6 +54,7 @@ vi.mock('@forge/react', () => ({
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
   Tooltip: React.Fragment,
+  Text: ({ children }) => <span>{children}</span>,
 }));
 
 // Import the App component
@@ -321,7 +322,7 @@ describe('Jira Fields Viewer App', () => {
       render(<App />);
 
       await waitFor(() => {
-        expect(screen.getByText('priority (3)')).toBeInTheDocument();
+        expect(screen.getByText('priority')).toBeInTheDocument();
         expect(screen.getByText('High, Low, Medium')).toBeInTheDocument();
       });
     });

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -53,6 +53,7 @@ vi.mock('@forge/react', () => ({
   Tab: ({ children }) => <button data-testid="tab">{children}</button>,
   TabPanel: ({ children }) => <div data-testid="tab-panel">{children}</div>,
   Box: ({ children, padding }) => <div data-testid="box" data-padding={padding}>{children}</div>,
+  Tooltip: React.Fragment,
 }));
 
 // Import the App component
@@ -85,6 +86,10 @@ const mockFields = [
     name: 'Priority',
     key: 'priority',
     schema: { type: 'priority' },
+    optionInfo: {
+      status: 'loaded',
+      options: ['High', 'Low', 'Medium'],
+    },
   },
 ];
 
@@ -268,6 +273,7 @@ describe('Jira Fields Viewer App', () => {
         expect(screen.getAllByText('Field Name').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Field ID').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Field Type').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Options').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Project Name').length).toBeGreaterThan(0);
       });
     });
@@ -306,6 +312,17 @@ describe('Jira Fields Viewer App', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Company Managed Fields')).toBeInTheDocument();
+      });
+    });
+
+    test('should display option values for option-based fields', async () => {
+      invoke.mockResolvedValue(mockFields);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText('priority (3)')).toBeInTheDocument();
+        expect(screen.getByText('High, Low, Medium')).toBeInTheDocument();
       });
     });
   });

--- a/atlassian-jira-fields-viewer/test/index.test.jsx
+++ b/atlassian-jira-fields-viewer/test/index.test.jsx
@@ -322,7 +322,7 @@ describe('Jira Fields Viewer App', () => {
       render(<App />);
 
       await waitFor(() => {
-        expect(screen.getByText('priority')).toBeInTheDocument();
+        expect(screen.getAllByText('priority').length).toBeGreaterThan(0);
         expect(screen.getByText('High, Low, Medium')).toBeInTheDocument();
       });
     });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -258,6 +258,15 @@ describe('Resolvers', () => {
       json: async () => body,
     });
 
+    const retryableResponse = (status) => ({
+      ok: false,
+      status,
+      headers: {
+        get: () => '0',
+      },
+      text: async () => `retryable ${status}`,
+    });
+
     it('should enrich option-based fields with de-duplicated sorted options', async () => {
       const fields = [
         {
@@ -321,6 +330,56 @@ describe('Resolvers', () => {
         status: 'loaded',
         options: ['Option A', 'Option B'],
       });
+    });
+
+    it('should retry when context request returns 429', async () => {
+      const fields = [
+        {
+          id: 'customfield_10000',
+          name: 'Priority',
+          schema: { type: 'option' },
+        },
+      ];
+
+      mockRequestJira
+        .mockResolvedValueOnce(okJsonResponse(fields))
+        .mockResolvedValueOnce(okJsonResponse([]))
+        .mockResolvedValueOnce(retryableResponse(429))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ id: '10' }] }))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ value: 'Alpha' }] }));
+
+      const result = await handler.getAllFields();
+
+      expect(result[0].optionInfo).toEqual({
+        status: 'loaded',
+        options: ['Alpha'],
+      });
+      expect(mockRequestJira).toHaveBeenCalledTimes(5);
+    });
+
+    it('should retry when option request returns 503', async () => {
+      const fields = [
+        {
+          id: 'customfield_10000',
+          name: 'Priority',
+          schema: { type: 'option' },
+        },
+      ];
+
+      mockRequestJira
+        .mockResolvedValueOnce(okJsonResponse(fields))
+        .mockResolvedValueOnce(okJsonResponse([]))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ id: '10' }] }))
+        .mockResolvedValueOnce(retryableResponse(503))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ value: 'Alpha' }] }));
+
+      const result = await handler.getAllFields();
+
+      expect(result[0].optionInfo).toEqual({
+        status: 'loaded',
+        options: ['Alpha'],
+      });
+      expect(mockRequestJira).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/atlassian-jira-fields-viewer/test/resolvers.test.js
+++ b/atlassian-jira-fields-viewer/test/resolvers.test.js
@@ -47,7 +47,9 @@ describe('Resolvers', () => {
       requestJira: mockRequestJira,
     });
     
-    route.mockImplementation((strings, ...values) => strings.join(''));
+    route.mockImplementation((strings, ...values) =>
+      strings.reduce((acc, str, idx) => acc + str + (values[idx] ?? ''), '')
+    );
   });
 
   describe('getAllFields', () => {
@@ -99,17 +101,20 @@ describe('Resolvers', () => {
         name: 'Team Field',
         scope: { project: { id: '10001' } },
         projectName: 'Project Alpha',
+        optionInfo: null,
       });
       expect(result[1]).toEqual({
         id: 'field2',
         name: 'Global Field',
         projectName: null,
+        optionInfo: null,
       });
       expect(result[2]).toEqual({
         id: 'field3',
         name: 'Another Team Field',
         scope: { project: { id: '10002' } },
         projectName: 'Project Beta',
+        optionInfo: null,
       });
     });
 
@@ -142,6 +147,7 @@ describe('Resolvers', () => {
         name: 'Orphan Field',
         scope: { project: { id: '99999' } },
         projectName: 'Unknown Project',
+        optionInfo: null,
       });
     });
 
@@ -241,6 +247,79 @@ describe('Resolvers', () => {
       expect(result).toHaveLength(3);
       result.forEach(field => {
         expect(field.projectName).toBe('Shared Project');
+        expect(field.optionInfo).toBeNull();
+      });
+    });
+  });
+
+  describe('option enrichment in getAllFields', () => {
+    const okJsonResponse = (body) => ({
+      ok: true,
+      json: async () => body,
+    });
+
+    it('should enrich option-based fields with de-duplicated sorted options', async () => {
+      const fields = [
+        {
+          id: 'customfield_10000',
+          name: 'Priority',
+          schema: { type: 'option' },
+        },
+      ];
+      const projects = [];
+
+      mockRequestJira
+        .mockResolvedValueOnce(okJsonResponse(fields))
+        .mockResolvedValueOnce(okJsonResponse(projects))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ id: '10' }, { id: '20' }] }))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ value: 'Beta' }, { value: 'Alpha' }] }))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ value: 'Alpha' }, { value: 'Gamma' }] }));
+
+      const result = await handler.getAllFields();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].optionInfo).toEqual({
+        status: 'loaded',
+        options: ['Alpha', 'Beta', 'Gamma'],
+      });
+    });
+
+    it('should fallback to create metadata when context options are empty', async () => {
+      const fields = [
+        {
+          id: 'customfield_10124',
+          name: 'Team Select',
+          schema: { type: 'option' },
+          scope: { project: { id: '10001' } },
+        },
+      ];
+      const projects = [{ id: '10001', name: 'Team Project' }];
+
+      mockRequestJira
+        .mockResolvedValueOnce(okJsonResponse(fields))
+        .mockResolvedValueOnce(okJsonResponse(projects))
+        .mockResolvedValueOnce(okJsonResponse({ values: [{ id: '10' }] }))
+        .mockResolvedValueOnce(okJsonResponse({ values: [] }))
+        .mockResolvedValueOnce(okJsonResponse({
+          projects: [
+            {
+              issuetypes: [
+                {
+                  fields: {
+                    customfield_10124: {
+                      allowedValues: [{ value: 'Option B' }, { value: 'Option A' }],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        }));
+
+      const result = await handler.getAllFields();
+      expect(result[0].optionInfo).toEqual({
+        status: 'loaded',
+        options: ['Option A', 'Option B'],
       });
     });
   });


### PR DESCRIPTION
## Summary
- move option fetching into the `getAllFields` resolver so the frontend performs a single invoke
- enrich option-based fields with `optionInfo` (loaded/error + options) while keeping project-name enrichment
- keep UI output equivalent by rendering field type counts, option previews, and tooltip text from resolver data
- update tests for options column and resolver option enrichment behavior

## Validation
- `npm run lint` passed
- `npm test` failed locally with Vitest startup `ERR_REQUIRE_ESM` in this environment